### PR TITLE
simple arguments for build configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV MASTER_URL="http://jenkins:8080" \
     # see entrypoint.d/install-packages.sh
     REQUIRED_PACKAGES=""
 
-RUN apk --no-cache add openjdk8-jre wget git
+
+ARG ADD_BUILD_PACKAGES=
+RUN apk --no-cache add openjdk8-jre wget git ${ADD_BUILD_PACKAGES}
 
 ADD root/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.11
+ARG BASE_IMAGE_VERSION=3.11
+FROM alpine:${BASE_IMAGE_VERSION}
 
 MAINTAINER Dmitry Karikh <the.dr.hax@gmail.com>
 


### PR DESCRIPTION
This pull request adds two backwards-compatible project features.

These changes add the ability to:
1. specify the Alpine base image version
2. add additional packages to be built into the image

For example, if you wanted to build an image that extends `alpine:edge` and includes the `python3` and `meson` packages (in addition to JRE, wget, & git) , you would simply run

```
docker build . --build-arg BASE_IMAGE_VERSION=edge --build-arg ADD_BUILD_PACKAGES="python3 meson"
```
Both arguments are entirely optional. If `BASE_IMAGE_VERSION` is unspecified, it defaults to `3.11` as to be compatible with your other projects out-of-the-box. If `BASE_IMAGE_VERSION` unspecified, it's empty.

Build-time configuration increases ease of maintenance, facilitates automated deployment, and reduces the need for users to fork and modify the project for trivial changes.

Thanks for your time and consideration of these changes :)